### PR TITLE
Added additional properties to pom.xml

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -16,6 +16,9 @@
 
         <test.file></test.file>
         <config.file>default</config.file>
+        
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
fixes issue with newser versions of maven. More Info:

1. https://stackoverflow.com/questions/49028810/error-source-option-1-5-is-no-longer-supported-use-1-6-or-later
2. https://github.com/spring-guides/gs-maven/issues/21

Signed-off-by: Varun Garg <varun.ga@browserstack.com>