### PR TITLE
Update Browserstack Local Java Dependency version

### DIFF
--- a/android/pom.xml
+++ b/android/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
         <groupId>com.browserstack</groupId>
         <artifactId>browserstack-local-java</artifactId>
-        <version>0.1.0</version>
+        <version>1.0.1</version>
     </dependency>
     <dependency>
         <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
Browserstack Local java dependency v0.1.0 fails to launch binary with force local flag. Updating it to v1.0.1