### PR TITLE
Incorrect name of tests in ios parallel.testng.xml

### DIFF
--- a/ios/testng-examples/src/test/resources/com/browserstack/run_parallel_test/parallel.testng.xml
+++ b/ios/testng-examples/src/test/resources/com/browserstack/run_parallel_test/parallel.testng.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Parallel" thread-count="2" parallel="tests">
-    <test name="ParallelTestPixel3">
+    <test name="ParallelTestIphone11Pro">
     <parameter name="deviceIndex" value="0"/>
         <classes>
             <class name="com.browserstack.run_parallel_test.ParallelTest"/>
         </classes>
     </test>
 
-    <test name="ParallelTestGalaxy10e">
+    <test name="ParallelTestIphone11ProMax">
     <parameter name="deviceIndex" value="1"/>
         <classes>
             <class name="com.browserstack.run_parallel_test.ParallelTest"/>


### PR DESCRIPTION
Updated it to correct names according to the ios/..../parallel.conf.json