### PR TITLE
Support multi data types in capabilities object

### DIFF
--- a/android/testng-examples/src/test/java/com/browserstack/run_first_test/BrowserStackTestNGTest.java
+++ b/android/testng-examples/src/test/java/com/browserstack/run_first_test/BrowserStackTestNGTest.java
@@ -40,7 +40,7 @@ public class BrowserStackTestNGTest {
         while (it.hasNext()) {
             Map.Entry pair = (Map.Entry)it.next();
             if(capabilities.getCapability(pair.getKey().toString()) == null){
-                capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+                capabilities.setCapability(pair.getKey().toString(), pair.getValue());
             }
         }
 

--- a/android/testng-examples/src/test/java/com/browserstack/run_local_test/BrowserStackTestNGTest.java
+++ b/android/testng-examples/src/test/java/com/browserstack/run_local_test/BrowserStackTestNGTest.java
@@ -43,7 +43,7 @@ public class BrowserStackTestNGTest {
         while (it.hasNext()) {
             Map.Entry pair = (Map.Entry)it.next();
             if(capabilities.getCapability(pair.getKey().toString()) == null){
-                capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+                capabilities.setCapability(pair.getKey().toString(), pair.getValue());
             }
         }
 

--- a/android/testng-examples/src/test/java/com/browserstack/run_parallel_test/BrowserStackTestNGTest.java
+++ b/android/testng-examples/src/test/java/com/browserstack/run_parallel_test/BrowserStackTestNGTest.java
@@ -42,7 +42,7 @@ public class BrowserStackTestNGTest {
         while (it.hasNext()) {
             Map.Entry pair = (Map.Entry)it.next();
             if(capabilities.getCapability(pair.getKey().toString()) == null){
-                capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+                capabilities.setCapability(pair.getKey().toString(), pair.getValue());
             }
         }
 

--- a/ios/testng-examples/src/test/java/com/browserstack/run_first_test/BrowserStackTestNGTest.java
+++ b/ios/testng-examples/src/test/java/com/browserstack/run_first_test/BrowserStackTestNGTest.java
@@ -41,7 +41,7 @@ public class BrowserStackTestNGTest {
     while (it.hasNext()) {
       Map.Entry pair = (Map.Entry)it.next();
       if(capabilities.getCapability(pair.getKey().toString()) == null){
-          capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+          capabilities.setCapability(pair.getKey().toString(), pair.getValue());
       }
     }
 

--- a/ios/testng-examples/src/test/java/com/browserstack/run_local_test/BrowserStackTestNGTest.java
+++ b/ios/testng-examples/src/test/java/com/browserstack/run_local_test/BrowserStackTestNGTest.java
@@ -43,7 +43,7 @@ public class BrowserStackTestNGTest {
     while (it.hasNext()) {
       Map.Entry pair = (Map.Entry)it.next();
       if(capabilities.getCapability(pair.getKey().toString()) == null){
-          capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+          capabilities.setCapability(pair.getKey().toString(), pair.getValue());
       }
     }
 

--- a/ios/testng-examples/src/test/java/com/browserstack/run_parallel_test/BrowserStackTestNGTest.java
+++ b/ios/testng-examples/src/test/java/com/browserstack/run_parallel_test/BrowserStackTestNGTest.java
@@ -42,7 +42,7 @@ public class BrowserStackTestNGTest {
     while (it.hasNext()) {
       Map.Entry pair = (Map.Entry)it.next();
       if(capabilities.getCapability(pair.getKey().toString()) == null){
-          capabilities.setCapability(pair.getKey().toString(), pair.getValue().toString());
+          capabilities.setCapability(pair.getKey().toString(), pair.getValue());
       }
     }
 


### PR DESCRIPTION
We want to support data types other than string in capabilities object.
Origin: `otherApps` capability did not work since we were wrapping it in string.