### PR TITLE
Update retired devices on the sdk branch (Pixel 6 Pro 12.0, iPhone XS)

### DIFF
--- a/android/testng-examples/browserstack.yml
+++ b/android/testng-examples/browserstack.yml
@@ -42,8 +42,8 @@ platforms:
   - deviceName: Samsung Galaxy S21
     osVersion: 11.0
     platformName: android
-  - deviceName: Google Pixel 6 Pro
-    osVersion: 12.0
+  - deviceName: Google Pixel 7
+    osVersion: 13.0
     platformName: android
 
 # =======================

--- a/ios/testng-examples/browserstack.yml
+++ b/ios/testng-examples/browserstack.yml
@@ -42,8 +42,8 @@ platforms:
   - deviceName: iPhone 13 Pro
     osVersion: 15
     platformName: ios
-  - deviceName: iPhone XS
-    osVersion: 14
+  - deviceName: iPhone 15 Pro
+    osVersion: 17
     platformName: ios
 
 # =======================


### PR DESCRIPTION
## What

The `sdk` branch still pins two devices BrowserStack has retired:

```diff
- deviceName: Google Pixel 6 Pro     →  + deviceName: Google Pixel 7
-   platformVersion: 12.0            →  +   platformVersion: 13.0
- deviceName: iPhone XS              →  + deviceName: iPhone 15 Pro
-   platformVersion: 14              →  +   platformVersion: 17
```

## Why

Sessions fail before any test runs:

```
[BROWSERSTACK_INVALID_DEVICE] Incorrect device name 'iphone xs' specified for the 'device'
Device google pixel 6 pro with version 12.0 not supported.
```

Checked against the live `app-automate/devices.json`:

| Device | Fleet status |
|---|---|
| Google Pixel 6 Pro | offered, but only on `15.0` / `15 Beta` — **12.0 is gone** |
| iPhone XS | **not in the fleet at all** |
| Google Pixel 7 · 13.0 | ✅ available |
| iPhone 15 Pro · 17 | ✅ available |

**`master` already carries current devices** (Pixel 8 Pro, OnePlus 11R, iPhone 15). This branch simply never received that refresh.

This repo is cloned at runtime by the BrowserStack SDK regression suite, which pins `-b sdk`, so **regression tests have been failing on this alone.**

## Verified — both directories, 6/6 device sessions

| Directory | Devices | Result |
|---|---|---|
| `android/testng-examples` | Pixel 7 13.0 · S22 Ultra 12.0 · S21 11.0 | ✅ 3/3 |
| `ios/testng-examples` | iPhone 15 Pro 17.3 · 14 Pro 16.3 · 13 Pro 15.6 | ✅ 3/3 |

App Automate builds: `SDK-6691 testng android verify` (`308a3e358abb4a359605d665a5675eb22944d1b8`) · `SDK-6691 testng ios verify` (`c30211463bf1f550da1eb4859de4e43300c2e8aa`) — both `done`, every session `passed`.
Dashboard: https://app-automate.browserstack.com/dashboard/v2/builds

## Related

**SDK-1910 — *"iOS sample repos broken due to deprecated devices being used"* — was closed *Done* in May 2025.** The device is still pinned here. This PR is that ticket's actual fix.

Tracked under SDK-6691.